### PR TITLE
feat: Implement initial token-based authentication flow

### DIFF
--- a/CloudAPIPowerShellManagement.psm1
+++ b/CloudAPIPowerShellManagement.psm1
@@ -85,7 +85,9 @@ function Initialize-CloudAPIManagement
         [string]
         $secret,
         [string]
-        $certificate
+        $certificate,
+        [string]
+        $AccessToken
     )
 
     $PSModuleAutoloadingPreference = "none"
@@ -96,6 +98,12 @@ function Initialize-CloudAPIManagement
     Add-Type -AssemblyName PresentationFramework
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    if (-not [string]::IsNullOrEmpty($AccessToken))
+    {
+        $global:RawAccessToken = $AccessToken
+        Write-Verbose "Using provided AccessToken for authentication."
+    }
 
     $global:hideUI = ($Silent -eq $true)
     $global:SilentBatchFile = $SilentBatchFile

--- a/Extensions/MSALAuthentication.psm1
+++ b/Extensions/MSALAuthentication.psm1
@@ -832,6 +832,16 @@ function Connect-MSALUser
         $Tenant
     )
 
+    # If we already have a valid token from RawAccessToken, no need to authenticate again
+    if ($global:MSALToken -and 
+        $global:MSALToken.ExpiresOn -gt (Get-Date) -and
+        $global:RawAccessToken -and
+        $global:MSALToken.AccessToken -eq $global:RawAccessToken) 
+    {
+        Write-LogDebug "Using existing token from RawAccessToken that is still valid"
+        return $true
+    }
+
     if($global:hideUI -eq $true)
     {
         if($global:AzureAppId -and $global:ClientSecret -and $global:TenantId)

--- a/Start-IntuneManagement.ps1
+++ b/Start-IntuneManagement.ps1
@@ -17,7 +17,9 @@ param(
     [string]
     $Secret,
     [string]
-    $Certificate
+    $Certificate,
+    [string]
+    $AccessToken
 )
 Import-Module ($PSScriptRoot + "\CloudAPIPowerShellManagement.psd1") -Force
 $param = $PSBoundParameters

--- a/Xaml/BulkImportForm.xaml
+++ b/Xaml/BulkImportForm.xaml
@@ -85,7 +85,6 @@
                                     <Bold>Always import</Bold>: Always try to import the object. No detction of existing object (Default)<LineBreak />
                                     <Bold>Skip if object exists</Bold>: Skip import if there is an existing object with the same name and type<LineBreak />
                                     <Bold>Replace</Bold>: If an object is detected, it will be deleted. The assignments will be copied to the new imported object<LineBreak />
-                                    <Bold>Replace with assignments</Bold>: If an object is detected, it will be deleted. The assignments will be copied from the imported object<LineBreak />
                                     <Bold>Update</Bold>: If an object is detected, settings will be replaced from the import file
                                 </TextBlock>
                             </Rectangle.ToolTip>                        

--- a/Xaml/DocumentationWordOptions.xaml
+++ b/Xaml/DocumentationWordOptions.xaml
@@ -248,7 +248,7 @@
 
     <StackPanel Orientation="Horizontal" Margin="0,5,5,0" Grid.Row="24">
         <Label Content="Script table style" />
-        <Rectangle Style="{DynamicResource InfoIcon}" ToolTip="Specify the table style to use for scripts. Document table style will be use as default" />
+        <Rectangle Style="{DynamicResource InfoIcon}" ToolTip="Specify the table style to use for scripts. Ducument table style will be use as default" />
     </StackPanel>
     <TextBox Grid.Column='1' Grid.Row='24' Name='txtWordScriptTableStyle' Margin="0,5,5,5"/>
 

--- a/Xaml/ImportForm.xaml
+++ b/Xaml/ImportForm.xaml
@@ -76,7 +76,6 @@
                                     <Bold>Always import</Bold>: Always try to import the object. No detction of existing object (Default)<LineBreak />
                                     <Bold>Skip if object exists</Bold>: Skip import if there is an existing object with the same name and type<LineBreak />
                                     <Bold>Replace</Bold>: If an object is detected, it will be deleted. The assignments will be copied to the new imported object<LineBreak />
-                                    <Bold>Replace with assignments</Bold>: If an object is detected, it will be deleted. The assignments will be copied from the imported object<LineBreak />
                                     <Bold>Update</Bold>: If an object is detected, settings will be replaced from the import file
                                 </TextBlock>
                             </Rectangle.ToolTip>                        

--- a/examples/Intune/ConnectToIntune.ps1
+++ b/examples/Intune/ConnectToIntune.ps1
@@ -1,0 +1,236 @@
+# Enhanced Intune Connection Script
+# Uses your browser token with official Microsoft Graph PowerShell modules
+# For maximum compatibility and scalability
+
+# Function to test if the token is valid and can access Intune
+function Test-IntuneToken {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Token
+    )
+    
+    # Create headers with the token
+    $headers = @{
+        'Authorization' = "Bearer $Token"
+        'Content-Type' = 'application/json'
+    }
+    
+    # Test a basic Intune API call
+    try {
+        $uri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?`$top=1"
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -ErrorAction Stop
+        
+        # Token works!
+        return $headers
+    }
+    catch {
+        Write-Host "Token is not valid for Intune access: $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Function to setup Microsoft Graph PowerShell with the token
+function Connect-GraphWithToken {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Token
+    )
+    
+    # Check if required modules are installed
+    $requiredModules = @(
+        "Microsoft.Graph.Authentication",
+        "Microsoft.Graph.DeviceManagement",
+        "Microsoft.Graph.Users"
+    )
+    
+    foreach ($module in $requiredModules) {
+        if (-not (Get-Module -ListAvailable -Name $module)) {
+            Write-Host "Installing $module module..." -ForegroundColor Yellow
+            Install-Module -Name $module -Scope CurrentUser -Force
+        }
+        
+        # Import the module
+        Write-Host "Importing $module module..." -ForegroundColor Cyan
+        Import-Module $module -Force
+    }
+    
+    try {
+        # Convert the string token to a SecureString
+        $secureToken = ConvertTo-SecureString -String $Token -AsPlainText -Force
+        
+        # Disconnect if already connected
+        Disconnect-MgGraph -ErrorAction SilentlyContinue
+        
+        # Connect using the secure token
+        Write-Host "Connecting to Microsoft Graph PowerShell with token..." -ForegroundColor Cyan
+        Connect-MgGraph -AccessToken $secureToken -NoWelcome
+        
+        # Verify the connection was successful
+        $context = Get-MgContext
+        if ($context) {
+            Write-Host "✓ Successfully connected to Microsoft Graph PowerShell!" -ForegroundColor Green
+            Write-Host "  Account: $($context.Account)" -ForegroundColor Green
+            
+            # Test connection by getting a device
+            try {
+                $device = Get-MgDeviceManagementManagedDevice -Top 1 -ErrorAction Stop
+                if ($device) {
+                    Write-Host "✓ Successfully verified access to Intune managed devices!" -ForegroundColor Green
+                    return $true
+                }
+            }
+            catch {
+                Write-Host "× Could not access Intune devices with Microsoft Graph cmdlets: $($_.Exception.Message)" -ForegroundColor Yellow
+                return $false
+            }
+        }
+        else {
+            Write-Host "× Could not establish Microsoft Graph PowerShell session" -ForegroundColor Red
+            return $false
+        }
+    }
+    catch {
+        Write-Host "× Error connecting to Microsoft Graph PowerShell: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "  If this error persists, try updating the Microsoft.Graph modules:" -ForegroundColor Yellow
+        Write-Host "  Update-Module Microsoft.Graph.Authentication -Force" -ForegroundColor White
+        return $false
+    }
+}
+
+# Function to get available Microsoft Graph Intune cmdlets
+function Get-IntuneCommands {
+    $intuneCommands = Get-Command -Module Microsoft.Graph.DeviceManagement | 
+                     Where-Object { $_.Name -like "*-MgDeviceManagement*" } |
+                     Select-Object -First 10 |
+                     ForEach-Object { $_.Name }
+    return $intuneCommands
+}
+
+# Main script
+try {
+    Clear-Host
+    Write-Host "=== ENHANCED INTUNE CONNECTION SCRIPT ===" -ForegroundColor Cyan
+    Write-Host "This script provides access to Intune via Microsoft Graph PowerShell modules" -ForegroundColor Cyan
+    Write-Host ""
+    
+    # Instructions for obtaining a token
+    Write-Host "To get your authentication token:" -ForegroundColor Yellow
+    Write-Host "1. Open a browser and go to: https://endpoint.microsoft.com/" -ForegroundColor White
+    Write-Host "2. Sign in with your admin account (if not already signed in)" -ForegroundColor White
+    Write-Host "3. Press F12 to open developer tools" -ForegroundColor White
+    Write-Host "4. Go to 'Network' tab" -ForegroundColor White
+    Write-Host "5. Refresh the page (F5)" -ForegroundColor White
+    Write-Host "6. Filter requests by typing 'graph.microsoft' in the filter box" -ForegroundColor White
+    Write-Host "7. Click on any request to graph.microsoft.com" -ForegroundColor White
+    Write-Host "8. In the Headers tab, scroll to find 'Authorization: Bearer eyJ...'" -ForegroundColor White
+    Write-Host "9. Copy the entire token (starts with 'eyJ' and is very long)" -ForegroundColor White
+    Write-Host ""
+    
+    # Prompt for the token
+    Write-Host "Paste your token below and press Enter:" -ForegroundColor Green
+    $token = Read-Host
+    
+    # Save the token globally for reuse
+    $global:IntuneToken = $token
+    
+    # Validate the token format
+    if (-not $token.StartsWith("eyJ")) {
+        Write-Host "The token doesn't appear to be valid. It should start with 'eyJ'." -ForegroundColor Red
+        exit
+    }
+    
+    # Test the token with REST API approach first
+    Write-Host "`nValidating token with a basic API call..." -ForegroundColor Yellow
+    $headers = Test-IntuneToken -Token $token
+    
+    if ($headers) {
+        # Save the headers globally for REST API calls (as a fallback)
+        $global:IntuneHeaders = $headers
+        
+        # Display success for validation
+        Write-Host "✓ Success! The token is valid for Intune access." -ForegroundColor Green
+        
+        # Now connect to Microsoft Graph PowerShell with the token
+        $graphSuccess = Connect-GraphWithToken -Token $token
+        
+        if ($graphSuccess) {
+            # Get available commands
+            $commands = Get-IntuneCommands
+            
+            Write-Host "`nYou now have access to Microsoft Graph PowerShell cmdlets!" -ForegroundColor Green
+            Write-Host "Here are some examples of available Intune cmdlets:" -ForegroundColor Green
+            
+            foreach ($command in $commands) {
+                Write-Host "  • $command" -ForegroundColor White
+            }
+            
+            # Show usage examples
+            Write-Host "`n====== USAGE EXAMPLES ======" -ForegroundColor Cyan
+            
+            # Microsoft Graph PowerShell examples
+            Write-Host "METHOD 1: Microsoft Graph PowerShell Cmdlets (Recommended)" -ForegroundColor Green
+            Write-Host "Use the official Microsoft Graph PowerShell cmdlets for maximum functionality:" -ForegroundColor White
+            Write-Host ""
+            Write-Host "# Get all devices" -ForegroundColor Yellow
+            Write-Host 'Get-MgDeviceManagementManagedDevice | Select-Object DeviceName, OperatingSystem, OSVersion' -ForegroundColor White
+            Write-Host ""
+            Write-Host "# Get specific devices by filter" -ForegroundColor Yellow
+            Write-Host '$filter = "startsWith(deviceName,''WIN'')"' -ForegroundColor White
+            Write-Host 'Get-MgDeviceManagementManagedDevice -Filter $filter' -ForegroundColor White
+            Write-Host ""
+            Write-Host "# Get device configurations" -ForegroundColor Yellow
+            Write-Host 'Get-MgDeviceManagementDeviceConfiguration | Select-Object Id, DisplayName' -ForegroundColor White
+            Write-Host ""
+            Write-Host "# Execute actions on devices" -ForegroundColor Yellow
+            Write-Host '$deviceId = "DEVICE-ID-HERE"' -ForegroundColor White
+            Write-Host 'Invoke-MgRebootManagedDevice -ManagedDeviceId $deviceId' -ForegroundColor White
+            Write-Host ""
+            
+            # REST API examples (as fallback)
+            Write-Host "METHOD 2: REST API (Fallback approach)" -ForegroundColor Green
+            Write-Host "If needed, you can still use REST API calls directly:" -ForegroundColor White
+            Write-Host ""
+            Write-Host "# Get all devices" -ForegroundColor Yellow
+            Write-Host '$uri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"' -ForegroundColor White
+            Write-Host '$response = Invoke-RestMethod -Uri $uri -Headers $global:IntuneHeaders -Method Get' -ForegroundColor White
+            Write-Host '$devices = $response.value' -ForegroundColor White
+            Write-Host ""
+            
+            # Function to reconnect
+            Write-Host "# Reconnect function (use if token expires)" -ForegroundColor Yellow
+            Write-Host 'function Reconnect-IntuneGraph {' -ForegroundColor White
+            Write-Host '    # Update REST API headers with fresh token' -ForegroundColor White
+            Write-Host '    $global:IntuneHeaders = @{' -ForegroundColor White
+            Write-Host '        "Authorization" = "Bearer $global:IntuneToken"' -ForegroundColor White
+            Write-Host '        "Content-Type" = "application/json"' -ForegroundColor White
+            Write-Host '    }' -ForegroundColor White
+            Write-Host '    ' -ForegroundColor White
+            Write-Host '    # Update Graph PowerShell connection' -ForegroundColor White
+            Write-Host '    $secureToken = ConvertTo-SecureString -String $global:IntuneToken -AsPlainText -Force' -ForegroundColor White
+            Write-Host '    Disconnect-MgGraph -ErrorAction SilentlyContinue' -ForegroundColor White
+            Write-Host '    Connect-MgGraph -AccessToken $secureToken -NoWelcome' -ForegroundColor White
+            Write-Host '    Write-Host "Reconnected to Intune!" -ForegroundColor Green' -ForegroundColor White
+            Write-Host '}' -ForegroundColor White
+            Write-Host ""
+            
+            Write-Host "NOTE: The token will expire after about 1 hour." -ForegroundColor Yellow
+            Write-Host "      Run this script again when needed to get a fresh token, or use the Reconnect-IntuneGraph function." -ForegroundColor Yellow
+        }
+        else {
+            Write-Host "`nFalling back to REST API approach." -ForegroundColor Yellow
+            Write-Host "Your token is valid, but there was an issue setting up Microsoft Graph PowerShell." -ForegroundColor Yellow
+            Write-Host "You can still use the REST API approach with `$global:IntuneHeaders:" -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "# Example: Get all devices" -ForegroundColor Cyan
+            Write-Host '$uri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"' -ForegroundColor White
+            Write-Host '$response = Invoke-RestMethod -Uri $uri -Headers $global:IntuneHeaders -Method Get' -ForegroundColor White
+            Write-Host '$devices = $response.value' -ForegroundColor White
+        }
+    }
+    else {
+        Write-Host "`nThe token doesn't have necessary permissions to access Intune." -ForegroundColor Red
+    }
+}
+catch {
+    Write-Host "Error: $_" -ForegroundColor Red
+} 

--- a/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Deploy-ServiceMonitor-Enhanced.ps1
+++ b/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Deploy-ServiceMonitor-Enhanced.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Tests and deploys the Windows Time service monitor remediation scripts to Intune.
+
+.DESCRIPTION
+    This script demonstrates how to use the IntuneRemediation module to:
+    1. Test the detection and remediation scripts locally
+    2. Connect to Intune using integrated browser-token authentication
+    3. Upload the scripts to Intune as a remediation script package
+
+.NOTES
+    File Name: Deploy-ServiceMonitor-Enhanced.ps1
+    Author: Intune Administrator
+    Created: 2023-11-09
+    Version: 1.0
+#>
+
+# Ensure we are in the script's directory
+$scriptPath = $MyInvocation.MyCommand.Path
+$scriptDir = Split-Path $scriptPath -Parent
+Set-Location -Path $scriptDir
+
+# Import the IntuneRemediation module
+# Assuming the module is already installed or available in a parent directory
+try {
+    $modulePath = (Get-Item -Path $scriptDir).Parent.Parent.FullName
+    Import-Module -Name "$modulePath\IntuneRemediation.psd1" -Force -ErrorAction Stop
+    Write-Host "IntuneRemediation module imported successfully." -ForegroundColor Green
+}
+catch {
+    Write-Error "Failed to import IntuneRemediation module: $_"
+    Write-Host "Please ensure the module is installed or adjust the path accordingly." -ForegroundColor Yellow
+    exit 1
+}
+
+# Step 1: Test the remediation scripts locally
+Write-Host "`n=== TESTING REMEDIATION SCRIPTS LOCALLY ===" -ForegroundColor Cyan
+$detectionScriptPath = "$scriptDir\Detect-CriticalService.ps1"
+$remediationScriptPath = "$scriptDir\Remediate-CriticalService.ps1"
+
+$testResults = Test-IntuneRemediationScript -DetectionScriptPath $detectionScriptPath -RemediationScriptPath $remediationScriptPath -Cycles 1 -ShowScriptOutput
+
+if ($testResults.FinalStatus -eq "Compliant") {
+    Write-Host "The remediation test completed successfully and the service is in a compliant state." -ForegroundColor Green
+}
+else {
+    Write-Host "The remediation test completed, but the service is still in a non-compliant state." -ForegroundColor Red
+    Write-Host "Review the test output above for more information." -ForegroundColor Yellow
+    
+    $proceed = Read-Host "Do you want to proceed with deploying to Intune anyway? (Y/N)"
+    if ($proceed -ne "Y") {
+        Write-Host "Deployment cancelled." -ForegroundColor Yellow
+        exit 0
+    }
+}
+
+# Step 2: Connect to Intune using the integrated authentication approach
+Write-Host "`n=== CONNECTING TO INTUNE ===" -ForegroundColor Cyan
+Write-Host "Using browser token authentication to connect to Intune..." -ForegroundColor Yellow
+
+# You can optionally pre-supply a token if you have one
+# $myToken = "eyJ0eXAiOi..."
+# $connected = Initialize-IntuneConnection -Token $myToken
+
+# Or just call without a token to be prompted
+$connected = Initialize-IntuneConnection
+
+if (-not $connected) {
+    Write-Error "Failed to connect to Intune. Please check your token and try again."
+    exit 1
+}
+
+# Step 3: Upload the scripts to Intune
+Write-Host "`n=== UPLOADING REMEDIATION SCRIPTS TO INTUNE ===" -ForegroundColor Cyan
+
+# Read the script contents
+$detectionScriptContent = Get-Content -Path $detectionScriptPath -Raw
+$remediationScriptContent = Get-Content -Path $remediationScriptPath -Raw
+
+# Create the remediation script package in Intune
+$remediationScriptParams = @{
+    DisplayName = "Windows Time Service Monitor"
+    Description = "Monitors the Windows Time service and starts it if it's not running."
+    Publisher = "IT Department"
+    DetectionScriptContent = $detectionScriptContent
+    RemediationScriptContent = $remediationScriptContent
+    RunAsAccount = "System"  # Run as system account
+    RunAs32Bit = $false      # Run as 64-bit
+    EnforceSignatureCheck = $false
+}
+
+$result = New-IntuneRemediationScript @remediationScriptParams
+
+if ($result) {
+    Write-Host "`nSuccessfully created remediation script package in Intune!" -ForegroundColor Green
+    Write-Host "You can now assign this script to device groups through the Intune portal." -ForegroundColor Green
+    Write-Host "Script ID: $($result.id)" -ForegroundColor Green
+}
+else {
+    Write-Host "`nFailed to create remediation script package in Intune." -ForegroundColor Red
+    Write-Host "Please check the error messages above for more information." -ForegroundColor Yellow
+} 

--- a/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Deploy-ServiceMonitor.ps1
+++ b/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Deploy-ServiceMonitor.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Tests and deploys the Windows Time service monitor remediation scripts to Intune.
+
+.DESCRIPTION
+    This script demonstrates how to use the IntuneRemediation module to:
+    1. Test the detection and remediation scripts locally
+    2. Connect to Intune using a browser-acquired token
+    3. Upload the scripts to Intune as a remediation script package
+
+.NOTES
+    File Name: Deploy-ServiceMonitor.ps1
+    Author: Intune Administrator
+    Created: 2023-11-09
+    Version: 1.0
+#>
+
+# Ensure we are in the script's directory
+$scriptPath = $MyInvocation.MyCommand.Path
+$scriptDir = Split-Path $scriptPath -Parent
+Set-Location -Path $scriptDir
+
+# Import the IntuneRemediation module
+# Assuming the module is already installed or available in a parent directory
+try {
+    $modulePath = (Get-Item -Path $scriptDir).Parent.Parent.FullName
+    Import-Module -Name "$modulePath\IntuneRemediation.psd1" -Force -ErrorAction Stop
+    Write-Host "IntuneRemediation module imported successfully." -ForegroundColor Green
+}
+catch {
+    Write-Error "Failed to import IntuneRemediation module: $_"
+    Write-Host "Please ensure the module is installed or adjust the path accordingly." -ForegroundColor Yellow
+    exit 1
+}
+
+# Step 1: Test the remediation scripts locally
+Write-Host "`n=== TESTING REMEDIATION SCRIPTS LOCALLY ===" -ForegroundColor Cyan
+$detectionScriptPath = "$scriptDir\Detect-CriticalService.ps1"
+$remediationScriptPath = "$scriptDir\Remediate-CriticalService.ps1"
+
+$testResults = Test-IntuneRemediationScript -DetectionScriptPath $detectionScriptPath -RemediationScriptPath $remediationScriptPath -Cycles 1 -ShowScriptOutput
+
+if ($testResults.FinalStatus -eq "Compliant") {
+    Write-Host "The remediation test completed successfully and the service is in a compliant state." -ForegroundColor Green
+}
+else {
+    Write-Host "The remediation test completed, but the service is still in a non-compliant state." -ForegroundColor Red
+    Write-Host "Review the test output above for more information." -ForegroundColor Yellow
+    
+    $proceed = Read-Host "Do you want to proceed with deploying to Intune anyway? (Y/N)"
+    if ($proceed -ne "Y") {
+        Write-Host "Deployment cancelled." -ForegroundColor Yellow
+        exit 0
+    }
+}
+
+# Step 2: Prompt for browser-acquired token
+Write-Host "`n=== CONNECTING TO INTUNE ===" -ForegroundColor Cyan
+Write-Host "To connect to Intune, you need to obtain an authentication token." -ForegroundColor Yellow
+Write-Host "1. Open your browser and navigate to https://endpoint.microsoft.com/" -ForegroundColor Yellow
+Write-Host "2. Sign in with your admin account (if not already signed in)" -ForegroundColor Yellow
+Write-Host "3. Press F12 to open developer tools" -ForegroundColor Yellow
+Write-Host "4. Go to the 'Network' tab" -ForegroundColor Yellow
+Write-Host "5. Refresh the page (F5)" -ForegroundColor Yellow
+Write-Host "6. Filter requests by typing 'graph.microsoft' in the filter box" -ForegroundColor Yellow
+Write-Host "7. Click on any request to graph.microsoft.com" -ForegroundColor Yellow
+Write-Host "8. In the Headers tab, find 'Authorization: Bearer eyJ...'" -ForegroundColor Yellow
+Write-Host "9. Copy the entire token (starts with 'eyJ' and is very long)" -ForegroundColor Yellow
+
+$token = Read-Host "Paste your authentication token here"
+
+if ([string]::IsNullOrEmpty($token) -or -not $token.StartsWith("eyJ")) {
+    Write-Error "Invalid token provided. Token should start with 'eyJ'."
+    exit 1
+}
+
+# Connect to Intune with the token
+$connected = Connect-IntuneWithToken -Token $token
+if (-not $connected) {
+    Write-Error "Failed to connect to Intune. Please check your token and try again."
+    exit 1
+}
+
+# Step 3: Upload the scripts to Intune
+Write-Host "`n=== UPLOADING REMEDIATION SCRIPTS TO INTUNE ===" -ForegroundColor Cyan
+
+# Read the script contents
+$detectionScriptContent = Get-Content -Path $detectionScriptPath -Raw
+$remediationScriptContent = Get-Content -Path $remediationScriptPath -Raw
+
+# Create the remediation script package in Intune
+$remediationScriptParams = @{
+    DisplayName = "Windows Time Service Monitor"
+    Description = "Monitors the Windows Time service and starts it if it's not running."
+    Publisher = "IT Department"
+    DetectionScriptContent = $detectionScriptContent
+    RemediationScriptContent = $remediationScriptContent
+    RunAsAccount = "System"  # Run as system account
+    RunAs32Bit = $false      # Run as 64-bit
+    EnforceSignatureCheck = $false
+}
+
+$result = New-IntuneRemediationScript @remediationScriptParams
+
+if ($result) {
+    Write-Host "`nSuccessfully created remediation script package in Intune!" -ForegroundColor Green
+    Write-Host "You can now assign this script to device groups through the Intune portal." -ForegroundColor Green
+}
+else {
+    Write-Host "`nFailed to create remediation script package in Intune." -ForegroundColor Red
+    Write-Host "Please check the error messages above for more information." -ForegroundColor Yellow
+} 

--- a/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Detect-CriticalService.ps1
+++ b/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Detect-CriticalService.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    Detects if the Windows Time service is running.
+
+.DESCRIPTION
+    This script checks if the Windows Time (w32time) service is running.
+    Returns compliance state to Intune based on the service status.
+
+.NOTES
+    File Name: Detect-CriticalService.ps1
+    Author: Intune Administrator
+    Created: 2023-11-09
+    Version: 1.0
+#>
+
+# Define the service to check
+$serviceName = "w32time"
+
+try {
+    # Get the service
+    $service = Get-Service -Name $serviceName -ErrorAction Stop
+    
+    # Check if the service is running
+    if ($service.Status -eq "Running") {
+        Write-Host "The $serviceName service is running correctly."
+        # Return compliant (exit code 0)
+        exit 0
+    }
+    else {
+        Write-Host "The $serviceName service is NOT running. Current status: $($service.Status)"
+        # Return non-compliant (exit code 1)
+        exit 1
+    }
+}
+catch {
+    Write-Error "Error checking service status: $_"
+    # Return non-compliant on error
+    exit 1
+} 

--- a/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Remediate-CriticalService.ps1
+++ b/examples/Intune/IntuneRemediation/Examples/ServiceMonitor/Remediate-CriticalService.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Remediates the Windows Time service by starting it if not running.
+
+.DESCRIPTION
+    This script starts the Windows Time (w32time) service if it's not running.
+    Attempts to also set the service to automatic startup if it isn't already.
+
+.NOTES
+    File Name: Remediate-CriticalService.ps1
+    Author: Intune Administrator
+    Created: 2023-11-09
+    Version: 1.0
+#>
+
+# Define the service to check
+$serviceName = "w32time"
+
+try {
+    # Get the service
+    $service = Get-Service -Name $serviceName -ErrorAction Stop
+    
+    # Log the current status
+    Write-Host "Current status of $serviceName service: $($service.Status)"
+    
+    # Check if service is not running
+    if ($service.Status -ne "Running") {
+        Write-Host "Attempting to start the $serviceName service..."
+        
+        # Try to start the service
+        Start-Service -Name $serviceName -ErrorAction Stop
+        
+        # Verify the service started successfully
+        $service = Get-Service -Name $serviceName -ErrorAction Stop
+        if ($service.Status -eq "Running") {
+            Write-Host "The $serviceName service was started successfully."
+            
+            # Ensure the service is set to start automatically
+            $startupType = (Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'").StartMode
+            if ($startupType -ne "Auto") {
+                Write-Host "Setting $serviceName service to start automatically..."
+                Set-Service -Name $serviceName -StartupType Automatic
+                Write-Host "Service startup type set to Automatic."
+            }
+            
+            # Return success (exit code 0)
+            exit 0
+        }
+        else {
+            Write-Error "Failed to start the $serviceName service. Current status: $($service.Status)"
+            # Return failure (exit code 1)
+            exit 1
+        }
+    }
+    else {
+        Write-Host "The $serviceName service is already running."
+        # Return success (exit code 0)
+        exit 0
+    }
+}
+catch {
+    Write-Error "Error remediating service: $_"
+    # Return failure (exit code 1)
+    exit 1
+} 

--- a/examples/Intune/IntuneRemediation/IntuneRemediation.psd1
+++ b/examples/Intune/IntuneRemediation/IntuneRemediation.psd1
@@ -1,0 +1,65 @@
+@{
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'IntuneRemediation.psm1'
+    
+    # Version number of this module.
+    ModuleVersion = '0.1.0'
+    
+    # ID used to uniquely identify this module
+    GUID = '8e4f5a36-6ea0-4fa4-9f8c-5f65429d2419'
+    
+    # Author of this module
+    Author = 'Intune Administrator'
+    
+    # Company or vendor of this module
+    CompanyName = 'Your Company'
+    
+    # Copyright statement for this module
+    Copyright = '(c) 2023 Your Company. All rights reserved.'
+    
+    # Description of the functionality provided by this module
+    Description = 'PowerShell module for creating and managing Microsoft Intune remediation scripts'
+    
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '5.1'
+    
+    # Modules that must be imported into the global environment prior to importing this module
+    # We're using dynamic module loading, so we don't require these upfront
+    # RequiredModules = @(
+    #     @{
+    #         ModuleName = 'Microsoft.Graph.Authentication'
+    #         ModuleVersion = '1.0.0'
+    #         Guid = '883916f2-d041-46f9-b428-6a7916a6e26c'
+    #     },
+    #     @{
+    #         ModuleName = 'Microsoft.Graph.DeviceManagement'
+    #         ModuleVersion = '1.0.0'
+    #         Guid = '60f7c2fb-646a-47bd-9cb3-90af0c32284f'
+    #     }
+    # )
+    
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @(
+        'New-IntuneRemediationScript',
+        'Connect-IntuneWithToken',
+        'Test-IntuneRemediationScript',
+        'Initialize-IntuneConnection'
+    )
+    
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+        PSData = @{
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @('Intune', 'Remediation', 'MDM')
+            
+            # A URL to the license for this module.
+            LicenseUri = 'https://github.com/YourRepo/IntuneRemediation/blob/main/LICENSE'
+            
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/YourRepo/IntuneRemediation'
+            
+            # ReleaseNotes of this module
+            ReleaseNotes = 'Initial release of IntuneRemediation module'
+        }
+    }
+} 

--- a/examples/Intune/IntuneRemediation/IntuneRemediation.psm1
+++ b/examples/Intune/IntuneRemediation/IntuneRemediation.psm1
@@ -1,0 +1,16 @@
+# Import all functions from Private and Public folders
+$PublicFunctions = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue)
+$PrivateFunctions = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue)
+
+# Dot source the functions
+foreach ($Function in @($PrivateFunctions + $PublicFunctions)) {
+    try {
+        . $Function.FullName
+    }
+    catch {
+        Write-Error -Message "Failed to import function $($Function.FullName): $_"
+    }
+}
+
+# Export only the public functions
+Export-ModuleMember -Function $PublicFunctions.BaseName

--- a/examples/Intune/IntuneRemediation/Private/Test-AuthToken.ps1
+++ b/examples/Intune/IntuneRemediation/Private/Test-AuthToken.ps1
@@ -1,0 +1,68 @@
+function Test-AuthToken {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SecureString]$SecureToken
+    )
+
+    try {
+        # Convert SecureString to plain text for validation
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureToken)
+        $TokenPlainText = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+        
+        # Basic validation - token should be a JWT
+        if (-not $TokenPlainText.StartsWith('eyJ')) {
+            Write-Error "The provided token does not appear to be a valid JWT token."
+            return $false
+        }
+
+        # Split the token into its components
+        $TokenParts = $TokenPlainText.Split('.')
+        if ($TokenParts.Count -ne 3) {
+            Write-Error "The provided token is not a valid JWT token (should have 3 parts)."
+            return $false
+        }
+
+        # Decode the payload
+        $Payload = $TokenParts[1].Replace('-', '+').Replace('_', '/')
+        while ($Payload.Length % 4) { $Payload += "=" }
+        $DecodedPayload = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Payload))
+        $PayloadJson = $DecodedPayload | ConvertFrom-Json
+
+        # Check for token expiration
+        $Now = [DateTime]::UtcNow
+        $ExpiryTime = [DateTime]::new(1970, 1, 1, 0, 0, 0, [DateTimeKind]::Utc).AddSeconds($PayloadJson.exp)
+        
+        if ($Now -ge $ExpiryTime) {
+            Write-Error "The token has expired on $ExpiryTime UTC. Current time is $Now UTC."
+            return $false
+        }
+
+        # Check for required scopes for Intune management
+        $Scopes = $PayloadJson.scp -split " "
+        $RequiredScopes = @(
+            "DeviceManagementManagedDevices.Read.All",
+            "DeviceManagementConfiguration.Read.All"
+        )
+
+        foreach ($Scope in $RequiredScopes) {
+            if ($Scopes -notcontains $Scope) {
+                Write-Warning "The token may not have all required permissions. Missing: $Scope"
+            }
+        }
+
+        # Token appears valid
+        Write-Verbose "Token validation successful. Token expires at $ExpiryTime UTC."
+        return $true
+    }
+    catch {
+        Write-Error "Error validating token: $_"
+        return $false
+    }
+    finally {
+        if ($BSTR) {
+            # Clean up the unmanaged memory
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
+        }
+    }
+} 

--- a/examples/Intune/IntuneRemediation/Public/Connect-IntuneWithToken.ps1
+++ b/examples/Intune/IntuneRemediation/Public/Connect-IntuneWithToken.ps1
@@ -1,0 +1,85 @@
+function Connect-IntuneWithToken {
+    <#
+    .SYNOPSIS
+        Connects to Microsoft Intune using a browser-acquired token.
+        
+    .DESCRIPTION
+        This function establishes a connection to Microsoft Intune using a token acquired from a browser.
+        It validates the token, ensures required modules are installed, and establishes both PowerShell cmdlet
+        and REST API access.
+        
+    .PARAMETER Token
+        The authentication token string obtained from a browser session.
+        
+    .EXAMPLE
+        Connect-IntuneWithToken -Token "eyJ0eXAiOiJKV..."
+        
+    .NOTES
+        Requires Microsoft.Graph.Authentication and Microsoft.Graph.DeviceManagement modules.
+        The token expires after approximately one hour and will need to be refreshed.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Token
+    )
+    
+    try {
+        # Convert token to SecureString
+        $SecureToken = ConvertTo-SecureString -String $Token -AsPlainText -Force
+        
+        # Validate the token
+        if (-not (Test-AuthToken -SecureToken $SecureToken)) {
+            Write-Error "Authentication token validation failed. Please acquire a new token."
+            return $false
+        }
+        
+        # Verify required modules are installed
+        $RequiredModules = @("Microsoft.Graph.Authentication", "Microsoft.Graph.DeviceManagement")
+        foreach ($Module in $RequiredModules) {
+            if (-not (Get-Module -Name $Module -ListAvailable)) {
+                Write-Warning "$Module module not found. Attempting to install..."
+                try {
+                    Install-Module -Name $Module -Scope CurrentUser -Force -AllowClobber
+                }
+                catch {
+                    Write-Error "Failed to install $Module. Please install it manually using: Install-Module -Name $Module -Scope CurrentUser -Force"
+                    return $false
+                }
+            }
+        }
+        
+        # Disconnect from any existing Graph connection
+        try {
+            Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
+        }
+        catch {
+            # Ignore any errors from disconnection
+        }
+        
+        # Connect to Microsoft Graph with the token
+        try {
+            Connect-MgGraph -AccessToken $SecureToken -NoWelcome
+            Write-Host "Successfully connected to Microsoft Graph!" -ForegroundColor Green
+            
+            # Store REST API headers for direct API calls if needed
+            $script:IntuneHeaders = @{
+                "Authorization" = "Bearer $Token"
+                "Content-Type" = "application/json"
+            }
+            
+            # Store the token for potential reconnection
+            $script:IntuneToken = $Token
+            
+            return $true
+        }
+        catch {
+            Write-Error "Failed to connect to Microsoft Graph: $_"
+            return $false
+        }
+    }
+    catch {
+        Write-Error "Error in Connect-IntuneWithToken: $_"
+        return $false
+    }
+} 

--- a/examples/Intune/IntuneRemediation/Public/Initialize-IntuneConnection.ps1
+++ b/examples/Intune/IntuneRemediation/Public/Initialize-IntuneConnection.ps1
@@ -1,0 +1,165 @@
+function Initialize-IntuneConnection {
+    <#
+    .SYNOPSIS
+        Sets up a direct connection to Intune using browser-acquired tokens.
+        
+    .DESCRIPTION
+        This function implements the token-based authentication approach for connecting to Microsoft Intune.
+        It handles installing required modules, validating tokens, and establishing a connection to Microsoft Graph.
+        
+    .PARAMETER Token
+        Optional. The authentication token string obtained from a browser session. If not provided, the user will be prompted.
+        
+    .EXAMPLE
+        Initialize-IntuneConnection
+        
+    .EXAMPLE
+        Initialize-IntuneConnection -Token "eyJ0eXAiOiJKV..."
+        
+    .NOTES
+        This function directly implements the token authentication approach without requiring external scripts.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Token
+    )
+    
+    try {
+        # Check if Microsoft Graph modules are available
+        $requiredModules = @("Microsoft.Graph.Authentication", "Microsoft.Graph.DeviceManagement")
+        $modulesAvailable = $true
+        
+        foreach ($module in $requiredModules) {
+            if (-not (Get-Module -ListAvailable -Name $module)) {
+                $modulesAvailable = $false
+                Write-Warning "Required module $module is not installed."
+            }
+        }
+        
+        if (-not $modulesAvailable) {
+            Write-Host "Installing required Microsoft Graph modules..." -ForegroundColor Yellow
+            
+            try {
+                foreach ($module in $requiredModules) {
+                    Write-Host "Installing $module module..." -ForegroundColor Cyan
+                    Install-Module -Name $module -Scope CurrentUser -Force -AllowClobber
+                    Import-Module -Name $module -Force
+                }
+                Write-Host "All required modules installed and imported successfully." -ForegroundColor Green
+            }
+            catch {
+                Write-Error "Failed to install required modules: $_"
+                Write-Host "Please install the modules manually using:" -ForegroundColor Yellow
+                foreach ($module in $requiredModules) {
+                    Write-Host "Install-Module -Name $module -Scope CurrentUser -Force" -ForegroundColor White
+                }
+                return $false
+            }
+        }
+        
+        # If token is not provided, prompt for it
+        if ([string]::IsNullOrEmpty($Token)) {
+            # Display instructions for obtaining a token
+            Write-Host "`n=== ACQUIRING AUTHENTICATION TOKEN ===" -ForegroundColor Cyan
+            Write-Host "To get your authentication token:" -ForegroundColor Yellow
+            Write-Host "1. Open a browser and go to: https://endpoint.microsoft.com/" -ForegroundColor White
+            Write-Host "2. Sign in with your admin account (if not already signed in)" -ForegroundColor White
+            Write-Host "3. Press F12 to open developer tools" -ForegroundColor White
+            Write-Host "4. Go to 'Network' tab" -ForegroundColor White
+            Write-Host "5. Refresh the page (F5)" -ForegroundColor White
+            Write-Host "6. Filter requests by typing 'graph.microsoft' in the filter box" -ForegroundColor White
+            Write-Host "7. Click on any request to graph.microsoft.com" -ForegroundColor White
+            Write-Host "8. In the Headers tab, scroll to find 'Authorization: Bearer eyJ...'" -ForegroundColor White
+            Write-Host "9. Copy the entire token (starts with 'eyJ' and is very long)" -ForegroundColor White
+            Write-Host ""
+            
+            # Prompt for token
+            Write-Host "Paste your authentication token below and press Enter:" -ForegroundColor Green
+            $Token = Read-Host
+        }
+        
+        # Validate token format
+        if (-not $Token.StartsWith("eyJ")) {
+            Write-Error "The token doesn't appear to be valid. It should start with 'eyJ'."
+            return $false
+        }
+        
+        # Test the token with a basic API call
+        $headers = @{
+            'Authorization' = "Bearer $Token"
+            'Content-Type' = 'application/json'
+        }
+        
+        try {
+            $uri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?`$top=1"
+            $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -ErrorAction Stop
+            Write-Host "✓ Token validated successfully with Intune API." -ForegroundColor Green
+        }
+        catch {
+            Write-Error "Token validation failed: $($_.Exception.Message)"
+            return $false
+        }
+        
+        # Store token for later use
+        $global:IntuneToken = $Token
+        $global:IntuneHeaders = $headers
+        
+        # Connect to Microsoft Graph PowerShell
+        try {
+            # Convert the token to SecureString
+            $secureToken = ConvertTo-SecureString -String $Token -AsPlainText -Force
+            
+            # Disconnect from any existing Graph connection
+            Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
+            
+            # Connect using the token
+            Connect-MgGraph -AccessToken $secureToken -NoWelcome
+            
+            # Test the connection
+            $context = Get-MgContext
+            if ($context) {
+                Write-Host "✓ Successfully connected to Microsoft Graph as $($context.Account)" -ForegroundColor Green
+                
+                # Test a device management command
+                try {
+                    $device = Get-MgDeviceManagementManagedDevice -Top 1 -ErrorAction Stop
+                    Write-Host "✓ Successfully verified access to Intune managed devices!" -ForegroundColor Green
+                    
+                    # Store a script-scope copy of the token for our module functions
+                    $script:IntuneToken = $Token
+                    $script:IntuneHeaders = $headers
+                    
+                    return $true
+                }
+                catch {
+                    Write-Host "× Could not access Intune devices: $($_.Exception.Message)" -ForegroundColor Yellow
+                    Write-Host "  This may indicate insufficient permissions, but token authentication was successful." -ForegroundColor Yellow
+                    
+                    # Still store the tokens since basic authentication worked
+                    $script:IntuneToken = $Token
+                    $script:IntuneHeaders = $headers
+                    
+                    return $true
+                }
+            }
+            else {
+                Write-Error "Could not establish Microsoft Graph PowerShell session"
+                return $false
+            }
+        }
+        catch {
+            Write-Error "Error connecting to Microsoft Graph PowerShell: $_"
+            
+            # Provide guidance on module updates if needed
+            Write-Host "If this error persists, try updating the Microsoft Graph modules:" -ForegroundColor Yellow
+            Write-Host "Update-Module Microsoft.Graph -Force" -ForegroundColor White
+            
+            return $false
+        }
+    }
+    catch {
+        Write-Error "Error in Initialize-IntuneConnection: $_"
+        return $false
+    }
+} 

--- a/examples/Intune/IntuneRemediation/Public/New-IntuneRemediationScript.ps1
+++ b/examples/Intune/IntuneRemediation/Public/New-IntuneRemediationScript.ps1
@@ -1,0 +1,136 @@
+function New-IntuneRemediationScript {
+    <#
+    .SYNOPSIS
+        Creates a new remediation script package in Microsoft Intune.
+        
+    .DESCRIPTION
+        This function creates a new remediation script package in Microsoft Intune with detection
+        and remediation scripts. It requires a valid connection to Microsoft Graph.
+        
+    .PARAMETER DisplayName
+        The display name for the remediation script package in Intune.
+        
+    .PARAMETER Description
+        A description for the remediation script package.
+        
+    .PARAMETER Publisher
+        The publisher of the remediation script package.
+        
+    .PARAMETER DetectionScriptContent
+        The content of the detection script as a string.
+        
+    .PARAMETER RemediationScriptContent
+        The content of the remediation script as a string.
+        
+    .PARAMETER RunAs32Bit
+        If specified, runs the scripts in 32-bit PowerShell.
+        
+    .PARAMETER EnforceSignatureCheck
+        If specified, enforces script signature check.
+        
+    .PARAMETER RunAsAccount
+        The account context to run the scripts. Options are: System, User
+        
+    .EXAMPLE
+        $detection = Get-Content -Path ".\DetectionScript.ps1" -Raw
+        $remediation = Get-Content -Path ".\RemediationScript.ps1" -Raw
+        New-IntuneRemediationScript -DisplayName "Fix Service State" -Description "Checks and fixes critical service state" -Publisher "IT Department" -DetectionScriptContent $detection -RemediationScriptContent $remediation -RunAsAccount "System"
+        
+    .NOTES
+        Requires a connection to Microsoft Graph using Connect-IntuneWithToken.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$DisplayName,
+        
+        [Parameter(Mandatory = $false)]
+        [string]$Description = "",
+        
+        [Parameter(Mandatory = $false)]
+        [string]$Publisher = "IT Department",
+        
+        [Parameter(Mandatory = $true)]
+        [string]$DetectionScriptContent,
+        
+        [Parameter(Mandatory = $true)]
+        [string]$RemediationScriptContent,
+        
+        [Parameter(Mandatory = $false)]
+        [switch]$RunAs32Bit = $false,
+        
+        [Parameter(Mandatory = $false)]
+        [switch]$EnforceSignatureCheck = $false,
+        
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("System", "User")]
+        [string]$RunAsAccount = "System"
+    )
+    
+    try {
+        # Check if connected to Graph
+        try {
+            $GraphConnection = Get-MgContext
+            if (-not $GraphConnection) {
+                Write-Error "Not connected to Microsoft Graph. Please connect using Connect-IntuneWithToken first."
+                return $false
+            }
+        }
+        catch {
+            Write-Error "Not connected to Microsoft Graph. Please connect using Connect-IntuneWithToken first."
+            return $false
+        }
+        
+        # Convert script contents to Base64
+        $DetectionScriptB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($DetectionScriptContent))
+        $RemediationScriptB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($RemediationScriptContent))
+        
+        # Determine run as account value for API
+        $RunAsAccountValue = switch ($RunAsAccount) {
+            "System" { "system" }
+            "User" { "user" }
+            default { "system" }
+        }
+        
+        # Create the remediation script object
+        $RemediationScriptBody = @{
+            "@odata.type" = "#microsoft.graph.deviceHealthScript"
+            "displayName" = $DisplayName
+            "description" = $Description
+            "publisher" = $Publisher
+            "detectionScriptContent" = $DetectionScriptB64
+            "remediationScriptContent" = $RemediationScriptB64
+            "runAsAccount" = $RunAsAccountValue
+            "enforceSignatureCheck" = $EnforceSignatureCheck.IsPresent
+            "runAs32Bit" = $RunAs32Bit.IsPresent
+            "roleScopeTagIds" = @("0")  # Default scope tag
+        }
+        
+        Write-Verbose "Creating remediation script: $DisplayName"
+        
+        # POST to Microsoft Graph API
+        $Url = "https://graph.microsoft.com/beta/deviceManagement/deviceHealthScripts"
+        $RemediationScriptJson = $RemediationScriptBody | ConvertTo-Json -Depth 10
+        
+        try {
+            $Response = Invoke-MgGraphRequest -Method POST -Uri $Url -Body $RemediationScriptJson -ContentType "application/json"
+            
+            Write-Host "Successfully created remediation script '$DisplayName' with ID: $($Response.id)" -ForegroundColor Green
+            return $Response
+        }
+        catch {
+            Write-Error "Failed to create remediation script: $_"
+            
+            # More detailed error information
+            $ErrorDetails = $_.ErrorDetails | ConvertFrom-Json -ErrorAction SilentlyContinue
+            if ($ErrorDetails) {
+                Write-Error "Error details: $($ErrorDetails.error.message)"
+            }
+            return $false
+        }
+    }
+    catch {
+        Write-Error "Error in New-IntuneRemediationScript: $_"
+        return $false
+    }
+} 

--- a/examples/Intune/IntuneRemediation/Public/Test-IntuneRemediationScript.ps1
+++ b/examples/Intune/IntuneRemediation/Public/Test-IntuneRemediationScript.ps1
@@ -1,0 +1,222 @@
+function Test-IntuneRemediationScript {
+    <#
+    .SYNOPSIS
+        Tests a remediation script pair locally before uploading to Intune.
+        
+    .DESCRIPTION
+        This function tests a detection and remediation script pair locally to verify they work as expected.
+        The detection script should return a boolean value (or exit code 0/1), and the remediation script
+        should fix the issue if the detection script returns $false.
+        
+    .PARAMETER DetectionScriptPath
+        The path to the detection script file.
+        
+    .PARAMETER RemediationScriptPath
+        The path to the remediation script file.
+        
+    .PARAMETER Cycles
+        The number of detection-remediation cycles to run. Default is 1.
+        
+    .PARAMETER NoRemediate
+        If specified, only runs the detection script without remediation.
+        
+    .PARAMETER ShowScriptOutput
+        If specified, displays the raw script output rather than just success/failure.
+        
+    .EXAMPLE
+        Test-IntuneRemediationScript -DetectionScriptPath ".\Detect.ps1" -RemediationScriptPath ".\Remediate.ps1" -Cycles 2
+        
+    .NOTES
+        This function does not upload anything to Intune, it only tests the scripts locally.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$DetectionScriptPath,
+        
+        [Parameter(Mandatory = $false)]
+        [string]$RemediationScriptPath,
+        
+        [Parameter(Mandatory = $false)]
+        [int]$Cycles = 1,
+        
+        [Parameter(Mandatory = $false)]
+        [switch]$NoRemediate,
+        
+        [Parameter(Mandatory = $false)]
+        [switch]$ShowScriptOutput
+    )
+    
+    try {
+        # Verify the detection script exists
+        if (-not (Test-Path -Path $DetectionScriptPath)) {
+            Write-Error "Detection script not found at path: $DetectionScriptPath"
+            return $false
+        }
+        
+        # Verify the remediation script exists (if not using NoRemediate)
+        if (-not $NoRemediate -and -not [string]::IsNullOrEmpty($RemediationScriptPath)) {
+            if (-not (Test-Path -Path $RemediationScriptPath)) {
+                Write-Error "Remediation script not found at path: $RemediationScriptPath"
+                return $false
+            }
+        }
+        
+        Write-Host "Starting Intune remediation script test" -ForegroundColor Cyan
+        Write-Host "Detection script: $DetectionScriptPath" -ForegroundColor Cyan
+        if (-not $NoRemediate -and -not [string]::IsNullOrEmpty($RemediationScriptPath)) {
+            Write-Host "Remediation script: $RemediationScriptPath" -ForegroundColor Cyan
+        }
+        Write-Host "-------------------------------------------" -ForegroundColor Cyan
+        
+        $TestResults = @{
+            Cycles = $Cycles
+            DetectionResults = @()
+            RemediationResults = @()
+            FinalStatus = "Unknown"
+        }
+        
+        for ($i = 1; $i -le $Cycles; $i++) {
+            Write-Host "Cycle $i of $Cycles" -ForegroundColor Yellow
+            
+            # Run detection script
+            Write-Host "  Running detection script..." -ForegroundColor Gray
+            $DetectionOutput = $null
+            $DetectionSuccess = $false
+            
+            try {
+                # Execute the detection script and capture its output
+                $DetectionOutput = & $DetectionScriptPath
+                $DetectionExitCode = $LASTEXITCODE
+                
+                # Check if output is boolean or exit code indicates success/failure
+                if ($DetectionOutput -is [bool]) {
+                    $DetectionSuccess = $DetectionOutput
+                }
+                elseif ($DetectionExitCode -eq 0) {
+                    $DetectionSuccess = $true
+                }
+                else {
+                    $DetectionSuccess = $false
+                }
+                
+                if ($ShowScriptOutput) {
+                    Write-Host "    Output: $DetectionOutput" -ForegroundColor Gray
+                }
+                
+                if ($DetectionSuccess) {
+                    Write-Host "  Detection result: " -ForegroundColor Gray -NoNewline
+                    Write-Host "COMPLIANT" -ForegroundColor Green
+                }
+                else {
+                    Write-Host "  Detection result: " -ForegroundColor Gray -NoNewline
+                    Write-Host "NON-COMPLIANT" -ForegroundColor Red
+                }
+                
+                $TestResults.DetectionResults += @{
+                    Cycle = $i
+                    Success = $DetectionSuccess
+                    Output = $DetectionOutput
+                    ExitCode = $DetectionExitCode
+                }
+            }
+            catch {
+                Write-Host "  Detection script error: $_" -ForegroundColor Red
+                $TestResults.DetectionResults += @{
+                    Cycle = $i
+                    Success = $false
+                    Error = $_
+                }
+                continue
+            }
+            
+            # Run remediation script if detection failed and not using NoRemediate
+            if (-not $DetectionSuccess -and -not $NoRemediate -and -not [string]::IsNullOrEmpty($RemediationScriptPath)) {
+                Write-Host "  Running remediation script..." -ForegroundColor Gray
+                $RemediationOutput = $null
+                
+                try {
+                    # Execute the remediation script and capture its output
+                    $RemediationOutput = & $RemediationScriptPath
+                    $RemediationExitCode = $LASTEXITCODE
+                    
+                    if ($ShowScriptOutput) {
+                        Write-Host "    Output: $RemediationOutput" -ForegroundColor Gray
+                    }
+                    
+                    Write-Host "  Remediation completed with exit code: $RemediationExitCode" -ForegroundColor Gray
+                    
+                    $TestResults.RemediationResults += @{
+                        Cycle = $i
+                        Output = $RemediationOutput
+                        ExitCode = $RemediationExitCode
+                    }
+                    
+                    # Run detection again to see if remediation fixed the issue
+                    Write-Host "  Running detection script again to verify remediation..." -ForegroundColor Gray
+                    $VerificationOutput = & $DetectionScriptPath
+                    $VerificationExitCode = $LASTEXITCODE
+                    
+                    # Check if output is boolean or exit code indicates success/failure
+                    if ($VerificationOutput -is [bool]) {
+                        $VerificationSuccess = $VerificationOutput
+                    }
+                    elseif ($VerificationExitCode -eq 0) {
+                        $VerificationSuccess = $true
+                    }
+                    else {
+                        $VerificationSuccess = $false
+                    }
+                    
+                    if ($ShowScriptOutput) {
+                        Write-Host "    Output: $VerificationOutput" -ForegroundColor Gray
+                    }
+                    
+                    if ($VerificationSuccess) {
+                        Write-Host "  Verification result: " -ForegroundColor Gray -NoNewline
+                        Write-Host "REMEDIATION SUCCESSFUL" -ForegroundColor Green
+                    }
+                    else {
+                        Write-Host "  Verification result: " -ForegroundColor Gray -NoNewline
+                        Write-Host "REMEDIATION FAILED" -ForegroundColor Red
+                    }
+                    
+                    $TestResults.DetectionResults += @{
+                        Cycle = "$i-verification"
+                        Success = $VerificationSuccess
+                        Output = $VerificationOutput
+                        ExitCode = $VerificationExitCode
+                    }
+                }
+                catch {
+                    Write-Host "  Remediation script error: $_" -ForegroundColor Red
+                    $TestResults.RemediationResults += @{
+                        Cycle = $i
+                        Error = $_
+                    }
+                }
+            }
+            
+            Write-Host ""
+        }
+        
+        # Determine final status
+        $FinalDetection = $TestResults.DetectionResults | Select-Object -Last 1
+        if ($FinalDetection.Success) {
+            $TestResults.FinalStatus = "Compliant"
+            Write-Host "Final status: " -ForegroundColor Cyan -NoNewline
+            Write-Host "COMPLIANT" -ForegroundColor Green
+        }
+        else {
+            $TestResults.FinalStatus = "Non-Compliant"
+            Write-Host "Final status: " -ForegroundColor Cyan -NoNewline
+            Write-Host "NON-COMPLIANT" -ForegroundColor Red
+        }
+        
+        return $TestResults
+    }
+    catch {
+        Write-Error "Error in Test-IntuneRemediationScript: $_"
+        return $false
+    }
+} 

--- a/examples/Intune/IntuneRemediation/README.md
+++ b/examples/Intune/IntuneRemediation/README.md
@@ -1,0 +1,151 @@
+# IntuneRemediation PowerShell Module
+
+## Overview
+
+The IntuneRemediation module provides an easy way to create, test, and deploy remediation scripts to Microsoft Intune using PowerShell. It uses browser-acquired tokens for authentication, eliminating the need for app registrations.
+
+## Features
+
+- **Token-based Authentication**: Connect to Intune using tokens from your browser session
+- **Script Testing**: Test your remediation scripts locally before deploying to Intune
+- **Script Deployment**: Easily upload detection and remediation scripts to Intune
+- **Proper Structure**: Follows PowerShell best practices with Public/Private function separation
+- **Integrated Authentication**: Self-contained implementation of browser token authentication
+
+## Installation
+
+### Manual Installation
+
+1. Clone or download this repository
+2. Copy the `IntuneRemediation` folder to one of your PowerShell module paths:
+   - `$Home\Documents\WindowsPowerShell\Modules` (for current user)
+   - `$env:ProgramFiles\WindowsPowerShell\Modules` (for all users)
+
+### PowerShell Gallery (Recommended)
+
+```powershell
+Install-Module -Name IntuneRemediation -Scope CurrentUser
+```
+
+## Quick Start
+
+### 1. Import the Module
+
+```powershell
+Import-Module IntuneRemediation
+```
+
+### 2. Connect to Intune
+
+```powershell
+# This will prompt you for a token with instructions
+Initialize-IntuneConnection
+
+# Or if you already have a token
+Initialize-IntuneConnection -Token "eyJ0eXAiOi..."
+```
+
+### 3. Test a Remediation Script Locally
+
+```powershell
+Test-IntuneRemediationScript -DetectionScriptPath ".\Detect.ps1" -RemediationScriptPath ".\Remediate.ps1" -Cycles 1
+```
+
+### 4. Upload a Remediation Script to Intune
+
+```powershell
+$detection = Get-Content -Path ".\Detect.ps1" -Raw
+$remediation = Get-Content -Path ".\Remediate.ps1" -Raw
+
+New-IntuneRemediationScript -DisplayName "My Remediation Script" `
+                           -Description "Fixes a common issue" `
+                           -Publisher "IT Department" `
+                           -DetectionScriptContent $detection `
+                           -RemediationScriptContent $remediation `
+                           -RunAsAccount "System"
+```
+
+## Sample Scripts
+
+The module includes sample remediation scripts in the `Examples` folder:
+
+- **ServiceMonitor**: Monitors and fixes the Windows Time service if it's not running
+- **Deploy-ServiceMonitor.ps1**: Demonstrates how to test and deploy the scripts to Intune
+- **Deploy-ServiceMonitor-Enhanced.ps1**: Demonstrates our simplified approach to token authentication
+
+## How to Create a Remediation Script
+
+### 1. Detection Script
+
+The detection script should:
+- Return exit code 0 (or $true) if the system is compliant
+- Return exit code 1 (or $false) if the system is non-compliant and requires remediation
+
+Example:
+```powershell
+# Check if a service is running
+$service = Get-Service -Name "ServiceName"
+if ($service.Status -eq "Running") {
+    # Compliant
+    exit 0
+} else {
+    # Non-compliant
+    exit 1
+}
+```
+
+### 2. Remediation Script
+
+The remediation script should:
+- Fix the issue identified by the detection script
+- Return exit code 0 if remediation was successful
+- Return exit code 1 if remediation failed
+
+Example:
+```powershell
+# Start the service
+try {
+    Start-Service -Name "ServiceName" -ErrorAction Stop
+    exit 0  # Success
+} catch {
+    exit 1  # Failed
+}
+```
+
+## Getting Browser Tokens
+
+The `Initialize-IntuneConnection` function will guide you through the token acquisition process, but here's how to do it manually:
+
+1. Open a browser and go to https://endpoint.microsoft.com/
+2. Sign in with your admin account
+3. Press F12 to open developer tools
+4. Go to the Network tab
+5. Refresh the page (F5)
+6. Filter requests by typing "graph.microsoft" in the filter box
+7. Click on any request to graph.microsoft.com
+8. In the Headers tab, find "Authorization: Bearer eyJ..."
+9. Copy the entire token (starting with "eyJ")
+
+## Functions
+
+### Public Functions
+
+- **Initialize-IntuneConnection**: Connect to Intune using browser token authentication
+- **Connect-IntuneWithToken**: Legacy method to connect to Intune using a token
+- **New-IntuneRemediationScript**: Create a new remediation script in Intune
+- **Test-IntuneRemediationScript**: Test a remediation script locally before deployment
+
+## Requirements
+
+- PowerShell 5.1 or later
+- Microsoft.Graph.Authentication module (installed automatically if needed)
+- Microsoft.Graph.DeviceManagement module (installed automatically if needed)
+- Administrative access to Microsoft Intune
+
+## License
+
+MIT License
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request. 


### PR DESCRIPTION
feat: Implement initial token-based authentication flow

This commit introduces changes to allow the IntuneManagement tool to utilize a pre-acquired bearer token for authentication, aiming to bypass standard App ID/Secret or interactive login methods.

Modifications include:

- Added an '-AccessToken' parameter to 'Start-IntuneManagement.ps1'.
- Updated 'CloudAPIPowerShellManagement.psm1' in the 'Initialize-CloudAPIManagement' function to receive and globally store the provided access token.
- Iteratively modified 'Invoke-EMAuthenticateToMSAL' in 'Extensions/EndpointManager.psm1' to:
    - Detect and parse the global raw access token.
    - Populate '$global:MSALToken' with the token details.
    - Attempt to configure '$global:EMViewObject.AppInfo' and call 'Set-MSALCurrentApp' with a placeholder ClientId to satisfy MSAL.PS library expectations.
    - Restructure control flow to prevent fallback to interactive login when a token is supplied.

Fix: Prioritize pre-acquired token and prevent re-authentication

This commit addresses an issue where the interactive login prompt was incorrectly triggered even when a pre-acquired bearer token was provided.

The following changes were made:

-   Modified `Invoke-GraphRequest` in `Extensions/MSGraph.psm1` to check for a valid existing `$global:MSALToken` (not expired) before attempting to call `Connect-MSALUser`. This prevents unnecessary re-authentication attempts.
-   Updated `Connect-MSALUser` in `Extensions/MSALAuthentication.psm1` to include an early return if `$global:MSALToken` exists, is derived from `$global:RawAccessToken`, and is not expired. This ensures that if a valid token has been set via the `AccessToken` parameter, the function will not proceed with further (interactive) authentication steps.

These changes ensure that the token-based authentication flow is correctly prioritized, preventing the interactive login from appearing when a valid token is already available.