### PR TITLE
Add Trim() to sanitize the organization displayName property

### DIFF
--- a/Extensions/MSALAuthentication.psm1
+++ b/Extensions/MSALAuthentication.psm1
@@ -259,6 +259,7 @@ function Get-MSALUserInfo
         if($global:Organization)
         {
             if($global:Organization -is [array]) { $global:Organization = $global:Organization[0]}
+            $global:Organization.displayName = ($global:Organization.displayName).Trim()
             Save-Setting $global:Organization.Id "_Name" $global:Organization.displayName
         }
         Set-EnvironmentInfo $global:Organization.displayName

--- a/Extensions/MSGraph.psm1
+++ b/Extensions/MSGraph.psm1
@@ -2708,7 +2708,7 @@ function Get-GraphMigrationTableFile
 
     if($global:chkAddCompanyName.IsChecked)
     {
-        $path = Join-Path $path $global:organization.displayName
+        $path = Join-Path $path $global:organization.displayName.Trim()
     }
     $path
 }
@@ -4263,7 +4263,7 @@ function Get-GraphObjectFolder
 
     $path = $rootFolder
 
-    if($addOrganization) { $path = Join-Path $path $global:organization.displayName }
+    if($addOrganization) { $path = Join-Path $path ($global:organization.displayName).Trim() }
 
     if($addObjectType -and $objectType.Id) { $path = Join-Path $path $objectType.Id }
 

--- a/Extensions/MSGraph.psm1
+++ b/Extensions/MSGraph.psm1
@@ -2708,7 +2708,7 @@ function Get-GraphMigrationTableFile
 
     if($global:chkAddCompanyName.IsChecked)
     {
-        $path = Join-Path $path ($global:organization.displayName).Trim()
+        $path = Join-Path $path $global:organization.displayName
     }
     $path
 }
@@ -4263,7 +4263,7 @@ function Get-GraphObjectFolder
 
     $path = $rootFolder
 
-    if($addOrganization) { $path = Join-Path $path ($global:organization.displayName).Trim() }
+    if($addOrganization) { $path = Join-Path $path $global:organization.displayName }
 
     if($addObjectType -and $objectType.Id) { $path = Join-Path $path $objectType.Id }
 

--- a/Extensions/MSGraph.psm1
+++ b/Extensions/MSGraph.psm1
@@ -2708,7 +2708,7 @@ function Get-GraphMigrationTableFile
 
     if($global:chkAddCompanyName.IsChecked)
     {
-        $path = Join-Path $path $global:organization.displayName.Trim()
+        $path = Join-Path $path ($global:organization.displayName).Trim()
     }
     $path
 }


### PR DESCRIPTION
In our environment we ran into an issue where the organization display name contained a trailing space (I have no idea how it got there, it is just there). 

Windows does not allow the creation of directories with leading or trailing spaces, so this broke the Intune Management app when including the organization name in the eport path).

This PR trims the leading and trailing spaces using the native .Trim() function, added in the `Get-GraphObjectFolder` function, where the path is constructed.