### PR TITLE
Fix .intunewin uploads when using powershell 7.4+

### DIFF
--- a/Extensions/IntuneAppManagement.psm1
+++ b/Extensions/IntuneAppManagement.psm1
@@ -521,6 +521,13 @@ function Write-AzureStorageChunk
         "Content-Type" = "application/octet-stream"
 	}
 
+    # In PowerShell (Core) 7 v7.4+, the web cmdlets (Invoke-WebRequest, Invoke-RestMethod)
+    # consistently encode text-based request bodies as UTF-8, unless explicitly specified otherwise.
+    if ($PSVersionTable.PSVersion -ge [Version]"7.4")
+    {
+        $headers["Content-Type"] += "; charset=iso-8859-1"
+    }
+
     $curProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
     


### PR DESCRIPTION
This PR fixes uploading of *.intunewin files of Intune apps in Powershell 7.4+.

In PowerShell (Core) v7.4+, the web cmdlets (Invoke-WebRequest, Invoke-RestMethod) consistently encode text-based request bodies as `UTF-8` (while the endpoint expects `iso-8859-1`) unless explicitly specified otherwise.
This PR adds the required `iso-8859-1` charset option to the header of the request. Only when powershell 7.4 or later is used.

More details: 

While using Powershell 7.4 (or later) the upload of the *.intunewin file fails during the importing with error:
```
File object created. ID: fe77fb2a-ed72-4c02-80ef-df9e580a870a
Wait for state AzureStorageUriRequest
Uploading file to Azure Storage

Uploading chunk 1 of 2 (50,00%)
Uploading file to Azure Storage

Uploading chunk 2 of 2 (100,00%)
Wait for state CommitFile
Failed to upload file. State: commitFileFailed
Failed to invoke MS Graph with URL https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/ababe66e-c7a6-4847-b5d1-9b26e612987d (Request ID: 18febd12-bdb0-4e17-ba23-30c403050ce4). Status code: BadRequest Exception: Response status code does not indicate success: 400 (Bad Request).
Upload finished for file _[redacted]_.intunewin version 1
Failed to invoke MS Graph with URL https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/ababe66e-c7a6-4847-b5d1-9b26e612987d/assign (Request ID: 6549128b-fc98-411c-a174-f99830dfcab6). Status code: BadRequest Exception: Response status code does not indicate success: 400 (Bad Request).
```
Importing the same app using Powershell version prior to 7.4 is successfully.


